### PR TITLE
Theme animation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,7 @@ dependencies = [
  "display-info",
  "gtk",
  "iced",
+ "iced_anim",
  "interprocess",
  "rdev",
  "rfd",
@@ -2245,6 +2246,27 @@ dependencies = [
  "iced_winit",
  "image 0.24.9",
  "thiserror",
+]
+
+[[package]]
+name = "iced_anim"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764a9667ffd3c98162cf594182d8c866e1d7231899089154476d09ec4347edf"
+dependencies = [
+ "iced",
+ "iced_anim_derive",
+ "serde",
+]
+
+[[package]]
+name = "iced_anim_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b89898a5300d2800451406a3d6cfaed89ef08797dc392143f7c16c5c747e95"
+dependencies = [
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ arboard = { version = "3.4", features = ["wayland-data-control", "wl-clipboard-r
 chrono = "0.4"
 display-info = { version = "0.5"}
 iced = { version = "0.13", features = ["advanced", "canvas", "multi-window", "image", "tokio", "svg"] }
+iced_anim = { version = "0.1.1", features = ["derive", "serde"] }
 interprocess = { version = "2.2", features = ["tokio"] }
 rdev = { git = "https://github.com/rustdesk-org/rdev", branch = "master"}
 rfd = { version = "0.14", features = ["gtk3", "tokio"], default-features = false }

--- a/src/entities/config.rs
+++ b/src/entities/config.rs
@@ -1,3 +1,4 @@
+use iced_anim::{Spring, SpringEvent};
 use serde::{Deserialize, Serialize};
 
 use crate::entities::theme::Theme;
@@ -5,7 +6,7 @@ use crate::entities::theme::Theme;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     #[serde(default)]
-    pub theme: Theme,
+    pub theme: Spring<Theme>,
     #[serde(default = "Config::default_path")]
     pub directory: String,
 }
@@ -20,6 +21,6 @@ pub struct ConfigureWindow {
 pub enum ConfigEvent {
     UpdateFolderPath,
     OpenFolder,
-    ToggleTheme,
+    UpdateTheme(SpringEvent<Theme>),
     RequestExit,
 }

--- a/src/entities/config.rs
+++ b/src/entities/config.rs
@@ -3,10 +3,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::entities::theme::Theme;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Config {
-    #[serde(default)]
     pub theme: Spring<Theme>,
+    pub directory: String,
+}
+
+/// The configuration that gets serialized to disk.
+/// This is distinct to avoid serializing animated values.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredConfig {
+    #[serde(default)]
+    pub theme: Theme,
     #[serde(default = "Config::default_path")]
     pub directory: String,
 }

--- a/src/entities/theme.rs
+++ b/src/entities/theme.rs
@@ -1,4 +1,5 @@
 use iced::Color;
+use iced_anim::Animate;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -6,8 +7,11 @@ pub enum Theme {
     #[default]
     Light,
     Dark,
+    #[serde(skip)]
+    Custom(Palette),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Animate)]
 pub struct Palette {
     pub background: Color,
     pub surface: Color,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use assets::{APPNAME, FONT_BOLD, FONT_MEDIUM, ICON, MEDIUM};
 use entities::{
     app::{App, AppEvent},
-    config::{Config, ConfigureWindow},
+    config::{Config, ConfigEvent, ConfigureWindow},
     crop::CropWindow,
     theme::Theme,
     window::WindowType,
@@ -28,6 +28,7 @@ use iced::{
     },
     Size, Subscription, Task,
 };
+use iced_anim::Animation;
 use interprocess::local_socket::{traits::Stream, GenericNamespaced, ToNsName};
 use style::Element;
 use utils::{
@@ -189,11 +190,13 @@ impl App {
             None => horizontal_space().into(),
         };
 
-        content
+        Animation::new(&self.config.theme, content)
+            .on_update(move |event| AppEvent::Config(id, ConfigEvent::UpdateTheme(event)))
+            .into()
     }
 
     pub fn theme(&self, _id: Id) -> Theme {
-        self.config.theme.clone()
+        self.config.theme.value().clone()
     }
 
     pub fn style(&self, theme: &Theme) -> Appearance {

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -40,6 +40,15 @@ impl Theme {
         match self {
             Theme::Light => LIGHT,
             Theme::Dark => DARK,
+            Theme::Custom(palette) => *palette,
+        }
+    }
+
+    /// Toggles the theme between light and dark, defaulting to `Light` if using a custom palette.
+    pub fn toggle(&self) -> Self {
+        match self {
+            Theme::Light => Theme::Dark,
+            _ => Theme::Light,
         }
     }
 }
@@ -49,6 +58,7 @@ impl Display for Theme {
         match self {
             Self::Light => write!(f, "Light"),
             Self::Dark => write!(f, "Dark"),
+            Self::Custom(_) => write!(f, "Custom"),
         }
     }
 }
@@ -59,5 +69,21 @@ impl DefaultStyle for Theme {
             background_color: self.palette().background,
             text_color: Color::default(),
         }
+    }
+}
+
+impl iced_anim::Animate for Theme {
+    fn components() -> usize {
+        Palette::components()
+    }
+
+    fn distance_to(&self, end: &Self) -> Vec<f32> {
+        self.palette().distance_to(&end.palette())
+    }
+
+    fn update(&mut self, components: &mut impl Iterator<Item = f32>) {
+        let mut palette = self.palette();
+        palette.update(components);
+        *self = Theme::Custom(palette);
     }
 }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -6,19 +6,17 @@ use std::{
     process::Command,
 };
 
+use iced_anim::Spring;
 use rfd::FileDialog;
 
-use crate::entities::{
-    config::{Config, ConfigureWindow},
-    theme::Theme,
-};
+use crate::entities::config::{Config, ConfigureWindow};
 
 use super::shorten_path;
 
 impl Default for Config {
     fn default() -> Self {
         Self {
-            theme: Theme::default(),
+            theme: Spring::default(),
             directory: Config::default_path(),
         }
     }
@@ -111,12 +109,6 @@ impl ConfigureWindow {
         Self {
             config: config.clone(),
             path: shorten_path(config.directory.clone()),
-        }
-    }
-    pub fn toggle_theme(&mut self) {
-        self.config.theme = match self.config.theme {
-            Theme::Light => Theme::Dark,
-            Theme::Dark => Theme::Light,
         }
     }
 

--- a/src/windows/config.rs
+++ b/src/windows/config.rs
@@ -9,6 +9,7 @@ use iced::{
     Length::Fill,
     Task,
 };
+use iced_anim::SpringEvent;
 
 use crate::{
     assets::{BOLD, SVG_FOLDER_OPEN},
@@ -31,9 +32,14 @@ impl ConfigureWindow {
                 self.open_directory();
                 Task::none()
             }
-            ConfigEvent::ToggleTheme => {
-                self.toggle_theme();
-                Task::done(AppEvent::UpdateConfig(id))
+            ConfigEvent::UpdateTheme(event) => {
+                if let SpringEvent::Target(_) = event {
+                    self.config.theme.update(event);
+                    Task::done(AppEvent::UpdateConfig(id))
+                } else {
+                    self.config.theme.update(event);
+                    Task::none()
+                }
             }
             ConfigEvent::RequestExit => Task::done(AppEvent::ExitApp),
         }
@@ -83,10 +89,16 @@ impl ConfigureWindow {
                 row![
                     text("App Theme").align_x(Left).size(22).font(BOLD),
                     horizontal_space().width(Fill),
-                    button(text(self.config.theme.to_string()).size(20).center())
-                        .height(40)
-                        .width(160)
-                        .on_press(ConfigEvent::ToggleTheme)
+                    button(
+                        text(self.config.theme.target().to_string())
+                            .size(20)
+                            .center()
+                    )
+                    .height(40)
+                    .width(160)
+                    .on_press(ConfigEvent::UpdateTheme(
+                        self.config.theme.target().toggle().into()
+                    ))
                 ]
                 .align_y(Alignment::Center)
                 .width(Fill)

--- a/src/windows/config.rs
+++ b/src/windows/config.rs
@@ -9,7 +9,6 @@ use iced::{
     Length::Fill,
     Task,
 };
-use iced_anim::SpringEvent;
 
 use crate::{
     assets::{BOLD, SVG_FOLDER_OPEN},
@@ -33,13 +32,8 @@ impl ConfigureWindow {
                 Task::none()
             }
             ConfigEvent::UpdateTheme(event) => {
-                if let SpringEvent::Target(_) = event {
-                    self.config.theme.update(event);
-                    Task::done(AppEvent::UpdateConfig(id))
-                } else {
-                    self.config.theme.update(event);
-                    Task::none()
-                }
+                self.config.theme.update(event);
+                Task::done(AppEvent::UpdateConfig(id))
             }
             ConfigEvent::RequestExit => Task::done(AppEvent::ExitApp),
         }


### PR DESCRIPTION
Implements a theme animation with the [iced_anim](https://crates.io/crates/iced_anim) crate. This changes the `Config` to contain a `Spring<Theme>` and implements `Animate` for `Palette` and `Theme` so that theme changes will be animated when the user changes the theme. A new `Theme::Custom` case is what enables animations because it takes any custom palette and allows the app to use that palette for theming. This `Custom` case is what allows the animated theme state to update and isn't serialized to disk at any point.

I also created a new `StoredConfig` struct that represents the serialized config, which is distinct from the `Config` struct since the latter may contain an animated state. This guarantees that the animated state value won't be serialized to disk. If you want to test this yourself, you can add a long response time to a `SpringMotion` on the `Spring::new` in `utils/config.rs` and exit the app before the animation is complete - you'll see that the final theme value is serialized and not the intermediate state.

Feel free to rename `Config` now that it represents less of a configuration and more of an app state - I went with `StoredConfig` to represent the new serialized config format just to avoid changing more of your app than necessary. Let me know if you have any questions!

https://github.com/user-attachments/assets/fb60e3a5-87fb-45c0-90ec-b74ce219f33b
